### PR TITLE
Enumerable array should have reasonable name

### DIFF
--- a/SillyXml.Tests/XmlSerializerTests.cs
+++ b/SillyXml.Tests/XmlSerializerTests.cs
@@ -36,6 +36,11 @@ namespace SillyXml.Tests
         public IEnumerable<int> Collection { get; } = new List<int> { 42, 15, 22 };
     }
 
+    public class ClassWithArrayEnumerable
+    {
+        public IEnumerable<int> Collection { get; } = new List<int> { 42, 15, 22 }.ToArray();
+    }
+
     public class ClassWithNull
     {
         public object NullObject { get; } = null;
@@ -179,6 +184,13 @@ namespace SillyXml.Tests
         {
             var str = XmlSerializer.Serialize(new ClassWithEnumerable());
             AreEqualXmlDisregardingWhitespace(@"<ClassWithEnumerable><Collection><Int32>42</Int32><Int32>15</Int32><Int32>22</Int32></Collection></ClassWithEnumerable>", str);
+        }
+
+        [Test]
+        public void Serialize_Class_With_Array_Enumerable()
+        {
+            var str = XmlSerializer.Serialize(new ClassWithArrayEnumerable());
+            AreEqualXmlDisregardingWhitespace(@"<ClassWithArrayEnumerable><Collection><Int32>42</Int32><Int32>15</Int32><Int32>22</Int32></Collection></ClassWithArrayEnumerable>", str);
         }
 
         [Test]

--- a/SillyXml/XmlSerializer.cs
+++ b/SillyXml/XmlSerializer.cs
@@ -140,6 +140,11 @@ namespace SillyXml
                 }
                 name += "Of";
                 name += string.Join("And", t.GenericTypeArguments.Select(NameForType).ToArray());
+            }else if (ti.IsArray)
+            {
+                name = "Array";
+                name += "Of";
+                name += string.Join("And", t.GenericTypeArguments.Select(NameForType).ToArray());
             }
             return name;
         }


### PR DESCRIPTION
When serializing IEnumerable that hides an array, I got an exception due to the name being generated contained "[". In order for the serialization to work without glitch, I've added a generated name for array.
